### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
   DisplayCopNames: true
 
 Layout/LineLength:
-  Max: 120
+  Max: 200
 Metrics/MethodLength:
   Include:
     - 'app/controllers/*'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.tabCompletion": "on",
+  "diffEditor.codeLens": true
+}

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,10 @@ gem 'stimulus-rails'
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jbuilder'
 
+gem 'bullet'
+
+gem "ffi"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 
@@ -58,6 +62,9 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
@@ -68,7 +75,5 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem 'capybara'
-  gem 'selenium-webdriver'
-  gem 'webdrivers'
+
 end

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'jbuilder'
 
 gem 'bullet'
 
-gem "ffi"
+gem 'ffi'
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
@@ -61,9 +61,9 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'web-console'
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'web-console'
   gem 'webdrivers'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
@@ -75,5 +75,4 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
     bootsnap (1.14.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.4)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.38.0)
       addressable
       matrix
@@ -89,6 +92,7 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     erubi (1.11.0)
+    ffi (1.15.5-x64-mingw32)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -207,6 +211,7 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.6)
       tzinfo (>= 1.0.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -229,8 +234,10 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
   debug
+  ffi
   importmap-rails
   jbuilder
   pagy (~> 5.10)
@@ -250,4 +257,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.1.4
+   2.3.26

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ rspec
 - Twitter: [@sipka_edii](https://twitter.com/sipka_edii)
 - LinkedIn: [Edi Sipka](https://www.linkedin.com/in/edi-%C5%A1ipka-5b681b202/)
 
+👤 **Peter Njuguna**
+
+- GitHub: [@peterboro](https://github.com/peterboro)
+- LinkedIn: [Peter Njuguna](https://www.linkedin.com/in/peter-n-3bb940122/)
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- FUTURE FEATURES -->

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,13 +1,13 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @pagy, @posts = pagy(@user.posts, items: 2)
+    @pagy, @posts = pagy(@user.posts.includes(:comments), items: 2)
   end
 
   def show
     @user = User.find(params[:user_id])
     @posts = Post.find(params[:id])
-    @comments = @posts.comments
+    @comments = @posts.comments.includes(:author)
   end
 
   def new

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -40,9 +40,11 @@
             <p class="card-text"><span class="text-muted">Likes: <%= post.likes_counter %></span></p>
           </div>
         </div>
+        
       <% end %>
     <% end %>
   <% end %>
+  
   <%= link_to "See all posts", user_posts_path(user_id: @user.id), class:"btn btn-dark mb-3" %>
 </div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,14 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time
@@ -51,6 +59,10 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raise an error on page load if there are pending migrations.
+  
+
+
+
   config.active_record.migration_error = :page_load
 
   # Highlight code that triggered database queries in logs.

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -52,4 +52,36 @@ RSpec.describe Post, type: :system do
       page.has_content?(subject.title)
     end
   end
+  describe 'Post show page' do
+    it "I can see a post's title." do
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(subject.title)
+    end
+    it 'I can see who wrote the post.' do
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(user.name)
+    end
+    it 'I can see how many comments it has.' do
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(subject.comments_counter)
+    end
+    it 'I can see how many likes it has.' do
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(subject.likes_counter)
+    end
+    it 'I can see the post body.' do
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(subject.text)
+    end
+    it 'I can see the username of each commentor.' do
+      comment = Comment.new(author_id: user.id, post_id: subject.id, text: 'I like it')
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(comment.author.name)
+    end
+    it 'I can see the comment each commentor left. ' do
+      comment = Comment.new(author_id: user.id, post_id: subject.id, text: 'I like it')
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(comment.text)
+    end
+  end
 end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,0 +1,45 @@
+=begin 
+I can see the user's profile picture.
+I can see the user's username.
+I can see the number of posts the user has written.
+I can see a post's title.
+I can see some of the post's body.
+I can see the first comments on a post.
+I can see how many comments a post has.
+I can see how many likes a post has.
+I can see a section for pagination if there are more posts than fit on the view.
+When I click on a post, it redirects me to that post's show page.
+=end
+
+require "rails_helper" 
+
+RSpec.describe Post, type: :system do
+  user = User.create(name: 'Anna', posts_counter: 3, photo: 'https://randomuser.me/api/portraits/women/67.jpg', bio: 'Project manager')
+
+  subject do
+    Post.new(author_id: user.id, title: "First post", text: "First post", comments_counter:2, likes_counter:2)
+  end
+  before {subject.save}
+
+  describe "Post index page" do 
+    it "I can see the user's profile picture." do
+      visit user_posts_path(user.id)
+      page.has_css?(".img-fluid")
+    end
+
+    it "I can see the user's username." do
+      visit user_posts_path(user.id)
+      page.has_content?(user.name)
+    end
+
+    it "I can see the number of posts the user has written." do
+      visit user_posts_path(user.id)
+      page.has_content?(user.posts_counter)
+    end
+
+    it "I can see a post's title." do
+      visit user_posts_path(user.id)
+      page.has_content?(subject.title)
+    end
+
+end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,30 +1,17 @@
-=begin 
-I can see the user's profile picture.
-I can see the user's username.
-I can see the number of posts the user has written.
-I can see a post's title.
-I can see some of the post's body.
-I can see the first comments on a post.
-I can see how many comments a post has.
-I can see how many likes a post has.
-I can see a section for pagination if there are more posts than fit on the view.
-When I click on a post, it redirects me to that post's show page.
-=end
-
-require "rails_helper" 
+require 'rails_helper'
 
 RSpec.describe Post, type: :system do
   user = User.create(name: 'Anna', posts_counter: 3, photo: 'https://randomuser.me/api/portraits/women/67.jpg', bio: 'Project manager')
 
   subject do
-    Post.new(author_id: user.id, title: "First post", text: "First post", comments_counter:2, likes_counter:2)
+    Post.new(author_id: user.id, title: 'First post', text: 'First post', comments_counter: 2, likes_counter: 2)
   end
-  before {subject.save}
+  before { subject.save }
 
-  describe "Post index page" do 
+  describe 'Post index page' do
     it "I can see the user's profile picture." do
       visit user_posts_path(user.id)
-      page.has_css?(".img-fluid")
+      page.has_css?('.img-fluid')
     end
 
     it "I can see the user's username." do
@@ -32,7 +19,7 @@ RSpec.describe Post, type: :system do
       page.has_content?(user.name)
     end
 
-    it "I can see the number of posts the user has written." do
+    it 'I can see the number of posts the user has written.' do
       visit user_posts_path(user.id)
       page.has_content?(user.posts_counter)
     end
@@ -42,4 +29,27 @@ RSpec.describe Post, type: :system do
       page.has_content?(subject.title)
     end
 
+    it "I can see some of the post's body." do
+      visit user_posts_path(user.id)
+      page.has_content?(subject.text)
+    end
+
+    it 'I can see the first comments on a post.' do
+      comment = Comment.new(author_id: user.id, post_id: subject.id, text: 'I like it')
+      visit user_posts_path(user.id)
+      page.has_content?(comment.text)
+    end
+
+    it 'I can see how many comments a post has.' do
+      visit user_posts_path(user.id)
+      page.has_content?(subject.comments_counter)
+    end
+
+    it 'When I click on a post, it redirects me to that posts show page.' do
+      visit user_posts_path(user.id)
+      click_on 'First post'
+      visit user_post_path(user.id, subject.id)
+      page.has_content?(subject.title)
+    end
+  end
 end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe User, type: :system do
+  subject { User.new(name: 'Anna', posts_counter: 3, photo: 'https://randomuser.me/api/portraits/women/67.jpg', bio: 'Project manager') }
+
+  before { subject.save }
+
+  describe "index page" do
+    it "I can see the username of all other users." do
+      visit root_path(subject)
+      page.has_content?(subject.name)
+    end
+
+    it "I can see the profile picture for each user" do
+    visit root_path(subject)
+    page.has_content?(subject.photo)
+  end
+
+  it "I can see the number of posts each user has written." do
+  visit root_path(subject)
+  page.has_content?(subject.posts_counter)
+end
+
+  it "When I click on a user, I am redirected to that user's show page." do
+  user2 = User.create(name: 'Lilly', posts_counter: 2, photo: 'https://randomuser.me/api/portraits/women/70.jpg', bio: 'Teacher from Poland.')
+  visit root_path(user2)
+  click_on "Lilly"
+  page.has_content?("Lilly")
+  end
+end 
+
+describe "User show page" do
+  it "I can see the user's profile picture." do
+    visit user_path(subject.id)
+    page.has_css?(".img-fluid")
+  end
+
+  it "I can see the user's username." do
+    visit user_path(subject.id)
+    page.has_content?(subject.name)
+  end
+
+  it "I can see the number of posts the user has written." do
+    visit user_path(subject.id)
+    page.has_content?(subject.posts_counter)
+  end
+
+  it "I can see the user's bio." do
+    visit user_path(subject.id)
+    page.has_content?(subject.bio)
+  end
+
+  it "I can see the user's first 3 posts." do
+    Post.create([{ author: subject, title: 'First Post', text: 'My first post' },
+    { author: subject, title: 'Second Post', text: 'My Second post' }, { author: subject, title: 'Third Post', text: 'My Third post' }])
+    visit user_path(subject.id)
+    page.has_content?(subject.posts)
+  end
+
+  it "I can see a button that lets me view all of a user's posts." do
+    visit user_path(subject.id)
+    page.has_button?("See all posts")
+  end
+
+  it "When I click a user's post, it redirects me to that post's show page." do
+    post = Post.create(author: subject, title: 'First Post', text: 'First post')
+    visit user_path(subject.id)
+    click_on "First post"
+    visit user_post_path(subject.id, post.id)
+    page.has_content?(post.title)
+  end
+
+  it "When I click to see all posts, it redirects me to the user's post's index page." do
+    visit user_path(subject.id)
+    click_on "See all posts"
+    visit user_posts_path(subject.id)
+    page.has_content?("Anna")
+  end
+ end
+end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,80 +1,80 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe User, type: :system do
   subject { User.new(name: 'Anna', posts_counter: 3, photo: 'https://randomuser.me/api/portraits/women/67.jpg', bio: 'Project manager') }
 
   before { subject.save }
 
-  describe "index page" do
-    it "I can see the username of all other users." do
+  describe 'index page' do
+    it 'I can see the username of all other users.' do
       visit root_path(subject)
       page.has_content?(subject.name)
     end
 
-    it "I can see the profile picture for each user" do
-    visit root_path(subject)
-    page.has_content?(subject.photo)
+    it 'I can see the profile picture for each user' do
+      visit root_path(subject)
+      page.has_content?(subject.photo)
+    end
+
+    it 'I can see the number of posts each user has written.' do
+      visit root_path(subject)
+      page.has_content?(subject.posts_counter)
+    end
+
+    it "When I click on a user, I am redirected to that user's show page." do
+      user2 = User.create(name: 'Lilly', posts_counter: 2, photo: 'https://randomuser.me/api/portraits/women/70.jpg', bio: 'Teacher from Poland.')
+      visit root_path(user2)
+      click_on 'Lilly'
+      page.has_content?('Lilly')
+    end
   end
 
-  it "I can see the number of posts each user has written." do
-  visit root_path(subject)
-  page.has_content?(subject.posts_counter)
-end
+  describe 'User show page' do
+    it "I can see the user's profile picture." do
+      visit user_path(subject.id)
+      page.has_css?('.img-fluid')
+    end
 
-  it "When I click on a user, I am redirected to that user's show page." do
-  user2 = User.create(name: 'Lilly', posts_counter: 2, photo: 'https://randomuser.me/api/portraits/women/70.jpg', bio: 'Teacher from Poland.')
-  visit root_path(user2)
-  click_on "Lilly"
-  page.has_content?("Lilly")
-  end
-end 
+    it "I can see the user's username." do
+      visit user_path(subject.id)
+      page.has_content?(subject.name)
+    end
 
-describe "User show page" do
-  it "I can see the user's profile picture." do
-    visit user_path(subject.id)
-    page.has_css?(".img-fluid")
-  end
+    it 'I can see the number of posts the user has written.' do
+      visit user_path(subject.id)
+      page.has_content?(subject.posts_counter)
+    end
 
-  it "I can see the user's username." do
-    visit user_path(subject.id)
-    page.has_content?(subject.name)
-  end
+    it "I can see the user's bio." do
+      visit user_path(subject.id)
+      page.has_content?(subject.bio)
+    end
 
-  it "I can see the number of posts the user has written." do
-    visit user_path(subject.id)
-    page.has_content?(subject.posts_counter)
-  end
+    it "I can see the user's first 3 posts." do
+      Post.create([{ author: subject, title: 'First Post', text: 'My first post' },
+                   { author: subject, title: 'Second Post', text: 'My Second post' }, { author: subject, title: 'Third Post', text: 'My Third post' }])
+      visit user_path(subject.id)
+      page.has_content?(subject.posts)
+    end
 
-  it "I can see the user's bio." do
-    visit user_path(subject.id)
-    page.has_content?(subject.bio)
-  end
+    it "I can see a button that lets me view all of a user's posts." do
+      visit user_path(subject.id)
+      page.has_button?('See all posts')
+    end
 
-  it "I can see the user's first 3 posts." do
-    Post.create([{ author: subject, title: 'First Post', text: 'My first post' },
-    { author: subject, title: 'Second Post', text: 'My Second post' }, { author: subject, title: 'Third Post', text: 'My Third post' }])
-    visit user_path(subject.id)
-    page.has_content?(subject.posts)
-  end
+    it "When I click a user's post, it redirects me to that post's show page." do
+      post = Post.create(author: subject, title: 'First Post', text: 'First post')
+      visit user_path(subject.id)
+      click_on 'First post'
+      visit user_post_path(subject.id, post.id)
+      page.has_content?(post.title)
+    end
 
-  it "I can see a button that lets me view all of a user's posts." do
-    visit user_path(subject.id)
-    page.has_button?("See all posts")
+    it "When I click to see all posts, it redirects me to the user's post's index page." do
+      visit user_path(subject.id)
+      click_on 'See all posts'
+      visit user_posts_path(subject.id)
+      page.has_content?('Anna')
+    end
   end
-
-  it "When I click a user's post, it redirects me to that post's show page." do
-    post = Post.create(author: subject, title: 'First Post', text: 'First post')
-    visit user_path(subject.id)
-    click_on "First post"
-    visit user_post_path(subject.id, post.id)
-    page.has_content?(post.title)
-  end
-
-  it "When I click to see all posts, it redirects me to the user's post's index page." do
-    visit user_path(subject.id)
-    click_on "See all posts"
-    visit user_posts_path(subject.id)
-    page.has_content?("Anna")
-  end
- end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,10 +3,12 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
+abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-
+require 'capybara/rails' 
+require 'capybara/rspec'
+require 'webdrivers'
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-require 'capybara/rails' 
+require 'capybara/rails'
 require 'capybara/rspec'
 require 'webdrivers'
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -33,7 +33,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = "#{Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,55 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  # The settings below are suggested to provide a good initial experience
-  # with RSpec, but feel free to customize to your heart's content.
-  #   # This allows you to limit a spec run to individual examples or groups
-  #   # you care about by tagging them with `:focus` metadata. When nothing
-  #   # is tagged with `:focus`, all examples get run. RSpec also provides
-  #   # aliases for `it`, `describe`, and `context` that include `:focus`
-  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
-  #
-  #   # Allows RSpec to persist some state between runs in order to support
-  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
-  #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
-  #
-  #   # Limits the available syntax to the non-monkey patched syntax that is
-  #   # recommended. For more details, see:
-  #   # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
-  #   config.disable_monkey_patching!
-  #
-  #   # This setting enables warnings. It's recommended, but in some cases may
-  #   # be too noisy due to issues in dependencies.
-  #   config.warnings = true
-  #
-  #   # Many RSpec users commonly either run the entire suite or an individual
-  #   # file, and it's useful to allow more verbose output when running an
-  #   # individual spec file.
-  #   if config.files_to_run.one?
-  #     # Use the documentation formatter for detailed output,
-  #     # unless a formatter has already been configured
-  #     # (e.g. via a command-line flag).
-  #     config.default_formatter = "doc"
-  #   end
-  #
-  #   # Print the 10 slowest examples and example groups at the
-  #   # end of the spec run, to help surface which specs are running
-  #   # particularly slow.
-  #   config.profile_examples = 10
-  #
-  #   # Run specs in random order to surface order dependencies. If you find an
-  #   # order dependency and want to debug it, you can fix the order by providing
-  #   # the seed, which is printed after each run.
-  #   #     --seed 1234
-  #   config.order = :random
-  #
-  #   # Seed global randomization in this process using the `--seed` CLI option.
-  #   # Setting this allows you to use `--seed` to deterministically reproduce
-  #   # test failures related to randomization by passing the same `--seed` value
-  #   # as the one that triggered the failure.
-  #   Kernel.srand config.seed
+# The settings below are suggested to provide a good initial experience
+# with RSpec, but feel free to customize to your heart's content.
+=begin
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
+  config.disable_monkey_patching!
+
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  config.warnings = true
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = "doc"
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+=end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,55 +44,53 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # This setting enables warnings. It's recommended, but in some cases may
+  #   # be too noisy due to issues in dependencies.
+  #   config.warnings = true
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
**_n+1_**
The N+1 problem is solved when fetching all posts and their comments for a user.


**_Integration specs_**

User index page:

- I can see the username of all other users.
- I can see the profile picture for each user.
- I can see the number of posts each user has written.
- When I click on a user, I am redirected to that user's show page.

User show page:

- I can see the user's profile picture.
- I can see the user's username.
- I can see the number of posts the user has written.
- I can see the user's bio.
- I can see the user's first 3 posts.
- I can see a button that lets me view all of a user's posts.
- When I click a user's post, it redirects me to that post's show page.
- When I click to see all posts, it redirects me to the user's post's index page.

User post index page:

- I can see the user's profile picture.
- I can see the user's username.
- I can see the number of posts the user has written.
- I can see a post's title.
- I can see some of the post's body.
- I can see the first comments on a post.
- I can see how many comments a post has.
- I can see how many likes a post has.
- I can see a section for pagination if there are more posts than fit on the view.
- When I click on a post, it redirects me to that post's show page.

Post show page:


- I can see the post's title.
- I can see who wrote the post.
- I can see how many comments it has.
- I can see how many likes it has.
- I can see the post body.
- I can see the username of each commentor.
- I can see the comment each commentor left.